### PR TITLE
Added instructions for Projucer setup (tested on MacOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,34 @@ You can keep the macros peppered around in your app during normal dev/release.
 
 Just remember to set `PERFETTO` back to `0` or `OFF` so everything gets turned into a no-op. 
 
+## Installing with Projucer
+
+### Step 1: Get Perfetto SDK
+```
+git clone https://android.googlesource.com/platform/external/perfetto -b v29.0
+```
+
+### Step 2: Add path to perfetto/sdk to your project root (necessary to actually compile perfetto tracing source)
+```
+sdk/perfetto.h
+sdk/perfetto.cc
+```
+
+### Step 3: Setup Projucer - Header Search Paths:
+```
+../../perfetto/sdk //path to perfetto/sdk
+```
+
+### Step 4: Setup Projucer - Preprocessor Definitions:
+```
+PERFETTO=1 //enabled
+```
+
+### Step 5: Setup Projucer - In Mac OS exporter:
+```
+App Sandbox Options: File Access: Read/Write: Download Folder (Read/Write) // to allow perfetto to write trace files
+```
+
 ## Customizing
 
 By default, there are two perfetto "categories" defined, `dsp` and `components`. 

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -94,9 +94,18 @@ private:
         auto mode = juce::String ("-RELEASE-");
     #endif
         auto currentTime = juce::Time::getCurrentTime().formatted ("%Y-%m-%d_%H%M");
-        auto output = file.getChildFile ("perfetto" + mode + currentTime + ".pftrace").createOutputStream();
-        output->setPosition (0);
-        output->write (&trace_data[0], trace_data.size() * sizeof (char));
+        auto childFile = file.getChildFile ("perfetto" + mode + currentTime + ".pftrace");
+        auto output = childFile.createOutputStream();
+        if(output) {
+            output->setPosition (0);
+            output->write (&trace_data[0], trace_data.size() * sizeof (char));
+
+            DBG("Wrote perfetto trace to: " + childFile.getFullPathName());
+        }
+        else {
+            DBG("Failed to write perfetto trace file. Check for missing permissions.");
+            jassertfalse;
+        }
     }
 
     std::unique_ptr<perfetto::TracingSession> session;


### PR DESCRIPTION
This is quick and dirty way of including and using module with Projucer. 
I think better way would be to include perfetto as submodule and reference it from this module. 

We could possibly do something similar to https://github.com/Tracktion/tracktion_engine/tree/master/modules with 3rd party.