### PR TITLE
MER-3340 Allow custom configs from user code

### DIFF
--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -50,6 +50,11 @@ public:
         cfg.add_buffers()->set_size_kb (buffer_size_kb); // 80MB is the default
         auto* ds_cfg = cfg.add_data_sources()->mutable_config();
         ds_cfg->set_name ("track_event");
+        beginSession (cfg);
+    }
+
+    void beginSession (const perfetto::TraceConfig& cfg)
+    {
         session = perfetto::Tracing::NewTrace();
         session->Setup (cfg);
         session->StartBlocking();


### PR DESCRIPTION
Looking at the relativelty little code in the Melatonin header I guess we can make our own wrapper form this if we need more functionalitybut this allows passing in a custom config, but it may be moot if that's not needed for the IPC tracing if we can get that working anyway!