### PR TITLE
Simplify usage and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 project(MelatoninPerfetto
-        VERSION 1.1.0
+        VERSION 1.3.0
         LANGUAGES CXX
         DESCRIPTION "JUCE module for profiling with Perfetto"
         HOMEPAGE_URL "https://github.com/sudara/melatonin_perfetto")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ message (STATUS "Cloning Perfetto...")
 
 FetchContent_Declare(Perfetto
     GIT_REPOSITORY https://android.googlesource.com/platform/external/perfetto
-    GIT_TAG v41.0
+    GIT_TAG v47.0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(MP_INSTALL_DEST "${CMAKE_INSTALL_LIBDIR}/cmake/melatonin_perfetto"
 
 
 message (STATUS "Grabbing Perfetto...")
-CPMAddPackage(gh:google/perfetto@48.1)
+CPMAddPackage(gh:google/perfetto@50.1)
 
 # we need to manually set up a target for Perfetto
 add_library(perfetto STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ set(MP_INSTALL_DEST "${CMAKE_INSTALL_LIBDIR}/cmake/melatonin_perfetto"
 
 message (STATUS "Cloning Perfetto...")
 
+#set(FETCHCONTENT_UPDATES_DISCONNECTED_Perfetto ON)
+
 FetchContent_Declare(Perfetto
     GIT_REPOSITORY https://android.googlesource.com/platform/external/perfetto
     GIT_TAG v41.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ if (MelatoninPerfetto_IS_TOP_LEVEL)
     message (STATUS "Cloning JUCE...")
 
     FetchContent_Declare(JUCE
-        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+        GIT_REPOSITORY https://github.com/sudara/JUCE.git
         GIT_TAG origin/master
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
-        FIND_PACKAGE_ARGS 7.0.9)
+        FIND_PACKAGE_ARGS develop)
 
     FetchContent_MakeAvailable(JUCE)
 endif ()

--- a/README.md
+++ b/README.md
@@ -377,6 +377,32 @@ If you use perfetto regularly, you can also do what I do and check for `PERFETTO
 
 <img width="384" alt="AudioPluginHost - 2023-01-06 44@2x" src="https://user-images.githubusercontent.com/472/211118327-e984f359-4e2f-4aec-8b4d-991093b36e67.png">
 
+## Running Perfetto in your tests
+
+It can be really nice to run a few test cases through perfetto. 
+
+To do so with Catch2, for example, you'll need to first link against `Catch2::Catch2` instead of `Catch2::Catch2WithMain`:
+
+```
+target_link_libraries(Tests PRIVATE SharedCode Catch2::Catch2WithMain)
+```
+
+And then define your own `main` function. 
+
+```cpp
+#include "melatonin_perfetto/melatonin_perfetto.h"
+int main (int argc, char* argv[])
+{
+#if PERFETTO
+    MelatoninPerfetto perfetto;
+#endif
+
+    const int result = Catch::Session().run (argc, argv);
+
+    return result;
+}
+```
+
 ## Running Melatonin::Perfetto's tests
 
 `melatonin_perfetto` includes a test suite using CTest. To run the tests, clone the code and run these commands:

--- a/README.md
+++ b/README.md
@@ -175,26 +175,15 @@ Include library:
 #include <melatonin_perfetto/melatonin_perfetto.h>
 ```
 
-Add a member of the plugin processor:
+Add a member of the plugin processor, guarded by a preprocessor definition:
 ```cpp
 #if PERFETTO
-    std::unique_ptr<perfetto::TracingSession> tracingSession;
+    MelatoninPerfetto tracingSession;
 #endif
 ```
 
-Put this in PluginProcessor's constructor:
+That's it! Earlier versions (1.2 and before) had MelatoninPerfetto as a singleton that you'd have to setup in the constructor, but now it's just a regular class. 
 
-```cpp
-#if PERFETTO
-    MelatoninPerfetto::get().beginSession();
-#endif
-```
-and in the destructor:
-```cpp
-#if PERFETTO
-    MelatoninPerfetto::get().endSession();
-#endif
-```
 ### Step 2: Pepper around some sweet sweet trace macros
 
 Perfetto will *only* measure functions you specifically tell it to.

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -16,9 +16,9 @@ END_JUCE_MODULE_DECLARATION
 #pragma once
 
 // I'm lazy and just toggle perfetto right here
-// But you can define it in your build system or in the file that includes this
+// But you can define it in your build system or in the file that includes this header
 #ifndef PERFETTO
-    #define PERFETTO 1
+    #define PERFETTO 0
 #endif
 
 #if PERFETTO

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -3,7 +3,7 @@ BEGIN_JUCE_MODULE_DECLARATION
 
  ID:                 melatonin_perfetto
  vendor:             Sudara
- version:            1.3.0
+ version:            1.4.0
  name:               Melatonin Perfetto
  description:        Perfetto module for JUCE
  license:            MIT
@@ -18,7 +18,7 @@ END_JUCE_MODULE_DECLARATION
 // I'm lazy and just toggle perfetto right here
 // But you can define it in your build system or in the file that includes this header
 #ifndef PERFETTO
-    #define PERFETTO 0
+    #define PERFETTO 1
 #endif
 
 #if PERFETTO

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -18,7 +18,7 @@ END_JUCE_MODULE_DECLARATION
 // I'm lazy and just toggle perfetto right here
 // But you can define it in your build system or in the file that includes this header
 #ifndef PERFETTO
-    #define PERFETTO 1
+    #define PERFETTO 0
 #endif
 
 #if PERFETTO

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -47,7 +47,7 @@ PERFETTO_DEFINE_CATEGORIES (
 class MelatoninPerfetto
 {
 public:
-    MelatoninPerfetto (bool startTrace = true) : startTraceAutomatically (startTrace)
+    explicit MelatoninPerfetto (const bool startTrace = true) : startTraceAutomatically (startTrace)
     {
         perfetto::TracingInitArgs args;
         // The backends determine where trace events are recorded. For this example we
@@ -62,7 +62,7 @@ public:
 
     ~MelatoninPerfetto()
     {
-        if (startTraceAutomatically)
+        if (started)
             endSession();
     }
 
@@ -75,6 +75,7 @@ public:
         session = perfetto::Tracing::NewTrace();
         session->Setup (cfg);
         session->StartBlocking();
+        started = true;
     }
 
     // Returns the file where the dump was written to (or a null file if an error occurred)
@@ -86,7 +87,7 @@ public:
 
         // Stop tracing
         session->StopBlocking();
-
+        started = false;
         return writeFile();
     }
 
@@ -101,6 +102,7 @@ public:
 
 private:
     bool startTraceAutomatically;
+    bool started = true;
     juce::File writeFile()
     {
         // Read trace data

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -3,7 +3,7 @@ BEGIN_JUCE_MODULE_DECLARATION
 
  ID:                 melatonin_perfetto
  vendor:             Sudara
- version:            1.2.0
+ version:            1.3.0
  name:               Melatonin Perfetto
  description:        Perfetto module for JUCE
  license:            MIT
@@ -18,7 +18,7 @@ END_JUCE_MODULE_DECLARATION
 // I'm lazy and just toggle perfetto right here
 // But you can define it in your build system or in the file that includes this
 #ifndef PERFETTO
-    #define PERFETTO 0
+    #define PERFETTO 1
 #endif
 
 #if PERFETTO
@@ -47,12 +47,21 @@ PERFETTO_DEFINE_CATEGORIES (
 class MelatoninPerfetto
 {
 public:
-    MelatoninPerfetto (const MelatoninPerfetto&) = delete;
-
-    static MelatoninPerfetto& get()
+    MelatoninPerfetto()
     {
-        static MelatoninPerfetto instance;
-        return instance;
+        perfetto::TracingInitArgs args;
+        // The backends determine where trace events are recorded. For this example we
+        // are going to use the in-process tracing service, which only includes in-app
+        // events.
+        args.backends = perfetto::kInProcessBackend;
+        perfetto::Tracing::Initialize (args);
+        perfetto::TrackEvent::Register();
+        beginSession();
+    }
+
+    ~MelatoninPerfetto()
+    {
+        endSession();
     }
 
     void beginSession (uint32_t buffer_size_kb = 80000)
@@ -89,17 +98,6 @@ public:
     }
 
 private:
-    MelatoninPerfetto()
-    {
-        perfetto::TracingInitArgs args;
-        // The backends determine where trace events are recorded. For this example we
-        // are going to use the in-process tracing service, which only includes in-app
-        // events.
-        args.backends = perfetto::kInProcessBackend;
-        perfetto::Tracing::Initialize (args);
-        perfetto::TrackEvent::Register();
-    }
-
     juce::File writeFile()
     {
         // Read trace data

--- a/tests/DumpFiles/main.cpp
+++ b/tests/DumpFiles/main.cpp
@@ -23,9 +23,7 @@ int szudzikPair (int a, int b)
 
 int main (int, char**)
 {
-	std::unique_ptr<perfetto::TracingSession> tracingSession;
-
-	MelatoninPerfetto::get().beginSession();
+	MelatoninPerfetto tracingSession;
 
 	auto& rand = juce::Random::getSystemRandom();
 
@@ -35,7 +33,7 @@ int main (int, char**)
 	for (auto i = 0; i < 100; ++i)
 		values.push_back (szudzikPair (rand.nextInt(), rand.nextInt()));
 
-	const auto dumpFile = MelatoninPerfetto::get().endSession();
+	const auto dumpFile = tracingSession.endSession();
 
 	if (dumpFile.existsAsFile())
 		return EXIT_SUCCESS;


### PR DESCRIPTION
This PR 

1. Simplifies installation by removing the singleton
3. Bumps the google dependency to version 50.1

## New usage:

```
#if PERFETTO
    MelatoninPerfetto tracingSession;
#endif
```

If you prefer to manually start the session, you can do so by passing `false` to the constructor and manually calling `.beginSession` and `.endSession`.


## Old usage:

```
#if PERFETTO
    std::unique_ptr<perfetto::TracingSession> tracingSession;
#endif

#if PERFETTO
    MelatoninPerfetto::get().beginSession();
#endif

#if PERFETTO
    MelatoninPerfetto::get().endSession();
#endif
```