### PR TITLE
Move dependencies to CPM for a better offline experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,11 @@ project(MelatoninPerfetto
 
 set(missing_juce_error_message "JUCE must be added to your project before melatonin_perfetto!")
 
-include(CPM)
+include(cmake/CPM.cmake)
 
 if (MelatoninPerfetto_IS_TOP_LEVEL)
     message (STATUS "Grabbing JUCE...")
-    CPMAddPackage(gh:juce-framework/JUCE)
+    CPMAddPackage("gh:juce-framework/JUCE#master")
 endif ()
 
 if (NOT COMMAND juce_add_module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,18 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 project(MelatoninPerfetto
-        VERSION 1.0.0
+        VERSION 1.1.0
         LANGUAGES CXX
         DESCRIPTION "JUCE module for profiling with Perfetto"
         HOMEPAGE_URL "https://github.com/sudara/melatonin_perfetto")
 
 set(missing_juce_error_message "JUCE must be added to your project before melatonin_perfetto!")
 
-include(FetchContent)
+include(CPM)
 
 if (MelatoninPerfetto_IS_TOP_LEVEL)
-    message (STATUS "Cloning JUCE...")
-
-    FetchContent_Declare(JUCE
-        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-        GIT_TAG origin/master
-        GIT_SHALLOW TRUE
-        GIT_PROGRESS TRUE
-        FIND_PACKAGE_ARGS 7.0.9)
-
-    FetchContent_MakeAvailable(JUCE)
+    message (STATUS "Grabbing JUCE...")
+    CPMAddPackage(gh:juce-framework/JUCE@master)
 endif ()
 
 if (NOT COMMAND juce_add_module)
@@ -33,15 +25,8 @@ set(MP_INSTALL_DEST "${CMAKE_INSTALL_LIBDIR}/cmake/melatonin_perfetto"
     CACHE STRING
     "Path below the install prefix where melatonin_perfetto package files will be installed to")
 
-message (STATUS "Cloning Perfetto...")
-
-FetchContent_Declare(Perfetto
-    GIT_REPOSITORY https://android.googlesource.com/platform/external/perfetto
-    GIT_TAG v41.0
-    GIT_SHALLOW TRUE
-    GIT_PROGRESS TRUE)
-
-FetchContent_MakeAvailable(Perfetto)
+message (STATUS "Grabbing Perfetto...")
+CPMAddPackage(gh:google/perfetto@48.1)
 
 # we need to manually set up a target for Perfetto
 add_library(perfetto STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CPM)
 
 if (MelatoninPerfetto_IS_TOP_LEVEL)
     message (STATUS "Grabbing JUCE...")
-    CPMAddPackage(gh:juce-framework/JUCE@master)
+    CPMAddPackage(gh:juce-framework/JUCE)
 endif ()
 
 if (NOT COMMAND juce_add_module)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
This module has always been a PITA re: offline access and configuring.

This moves the module to use CPM, which:

* Allows offline configuring / building (once perfetto has been downloaded once)
* Is compatible with a parent project using CPM

This also bumps perfetto to v48.1

Something like the following needs to be in your .zshrc or .bashrc:

export CPM_SOURCE_CACHE=$HOME/.cache/CPM

This also makes it friendlier in CI, see: https://github.com/cpm-cmake/CPM.cmake/wiki/Caching-with-CPM.cmake-and-ccache-on-GitHub-Actions
