### PR TITLE
Fix #6, customisable file name and support for global instant events

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+# https://forum.juce.com/t/automatic-juce-like-code-formatting-with-clang-format/31624/20
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BraceWrapping: # Allman except for lambdas
+  AfterClass: true
+  AfterCaseLabel: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  BeforeElse: true
+  AfterControlStatement: Always
+  BeforeLambdaBody: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: false
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+FixNamespaceComments: false
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: NonEmptyParentheses
+SpaceInEmptyParentheses: false
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+SpacesInSquareBrackets: false
+Standard: "c++20"
+TabWidth: 4
+UseTab: Never
+UseCRLF: false
+---
+Language: ObjC
+BasedOnStyle: Chromium
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1
+TabWidth: 4
+UseTab: Never

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -335,14 +335,15 @@ namespace melatonin
 
     #define TRACE_COMPONENT_BEGIN(name) TRACE_EVENT_BEGIN ("component", perfetto::StaticString (name))
     #define TRACE_COMPONENT_END() TRACE_EVENT_END ("component")
-#else
-    #define TRACE_COMPONENT(...)
-    #define TRACE_COMPONENT_BEGIN(name)
-    #define TRACE_COMPONENT_END()
 
     /**
      * Tracks an instant event, which shows up as an arrow on a separate "Global Events" track in the Perfetto UI.
      * @param name Describe the event - this is what shows up in the trace.
      */
     #define TRACE_COMPONENT_GLOBAL_INSTANT(name) TRACE_GLOBAL_INSTANT ("component", perfetto::StaticString (name))
+#else
+    #define TRACE_COMPONENT(...)
+    #define TRACE_COMPONENT_BEGIN(name)
+    #define TRACE_COMPONENT_END()
+    #define TRACE_COMPONENT_GLOBAL_INSTANT(name)
 #endif

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -7,7 +7,7 @@ BEGIN_JUCE_MODULE_DECLARATION
  name:               Melatonin Perfetto
  description:        Perfetto module for JUCE
  license:            MIT
- dependencies:       juce_core
+ dependencies:       juce_events
  minimumCppStandard: 17
 
 END_JUCE_MODULE_DECLARATION
@@ -34,7 +34,8 @@ END_JUCE_MODULE_DECLARATION
 
     #include <chrono>
     #include <fstream>
-    #include <juce_core/juce_core.h>
+    #include <future>
+    #include <juce_events/juce_events.h>
     #include <perfetto.h>
     #include <thread>
 
@@ -47,7 +48,17 @@ PERFETTO_DEFINE_CATEGORIES (
 class MelatoninPerfetto
 {
 public:
-    explicit MelatoninPerfetto (const bool startTrace = true) : startTraceAutomatically (startTrace)
+    explicit MelatoninPerfetto (const bool startTrace = true, juce::String filePrefix = "perfetto", juce::String fileSuffix = ".pftrace")
+        : startTraceAutomatically (startTrace),
+          prefix (filePrefix),
+          suffix (fileSuffix),
+          fileWriterCallback ([this] {
+              session->FlushBlocking();
+              session->ReadTrace ([&] (auto args) {
+                  if (!traceFile.appendData (args.data, args.size))
+                      DBG ("Failed to append perfetto trace data.");
+              });
+          })
     {
         perfetto::TracingInitArgs args;
         // The backends determine where trace events are recorded. For this example we
@@ -76,6 +87,9 @@ public:
         session->Setup (cfg);
         session->StartBlocking();
         started = true;
+
+        traceFile = getNewFile();
+        fileWriterCallback.startTimerHz (1);
     }
 
     // Returns the file where the dump was written to (or a null file if an error occurred)
@@ -85,10 +99,23 @@ public:
         // Make sure the last event is closed for this example.
         perfetto::TrackEvent::Flush();
 
-        // Stop tracing
+        fileWriterCallback.stopTimer();
         session->StopBlocking();
         started = false;
-        return writeFile();
+
+        // Block until the final trace data is fully written.
+        std::promise<void> writeDone;
+        session->ReadTrace ([&] (auto args) {
+            if (!traceFile.appendData (args.data, args.size))
+                DBG ("Failed to append perfetto trace data.");
+
+            if (!args.has_more)
+                writeDone.set_value();
+        });
+
+        writeDone.get_future().wait();
+
+        return traceFile;
     }
 
     static juce::File getDumpFileDirectory()
@@ -106,12 +133,36 @@ public:
 private:
     bool startTraceAutomatically;
     bool started = false;
+    juce::String prefix;
+    juce::String suffix;
+    std::unique_ptr<perfetto::TracingSession> session;
+    juce::File traceFile;
+    juce::TimedCallback fileWriterCallback;
+
     juce::File writeFile()
     {
         // Read trace data
         std::vector<char> trace_data (session->ReadTraceBlocking());
+        const auto file = getNewFile();
 
-        const auto file = getDumpFileDirectory();
+        if (auto output = file.createOutputStream())
+        {
+            output->setPosition (0);
+            output->write (&trace_data[0], trace_data.size() * sizeof (char));
+
+            DBG ("Wrote perfetto trace to: " + file.getFullPathName());
+
+            return file;
+        }
+
+        DBG ("Failed to write perfetto trace file. Check for missing permissions.");
+        jassertfalse;
+        return juce::File {};
+    }
+
+    [[nodiscard]] juce::File getNewFile() const
+    {
+        const auto directory = getDumpFileDirectory();
 
     #if JUCE_DEBUG
         auto mode = juce::String ("-DEBUG-");
@@ -120,24 +171,9 @@ private:
     #endif
 
         const auto currentTime = juce::Time::getCurrentTime().formatted ("%Y-%m-%d_%H%M");
-        const auto childFile = file.getChildFile ("perfetto" + mode + currentTime + ".pftrace");
-
-        if (auto output = childFile.createOutputStream())
-        {
-            output->setPosition (0);
-            output->write (&trace_data[0], trace_data.size() * sizeof (char));
-
-            DBG ("Wrote perfetto trace to: " + childFile.getFullPathName());
-
-            return childFile;
-        }
-
-        DBG ("Failed to write perfetto trace file. Check for missing permissions.");
-        jassertfalse;
-        return juce::File {};
+        const auto childFile = directory.getNonexistentChildFile (prefix + mode + currentTime, suffix);
+        return childFile;
     }
-
-    std::unique_ptr<perfetto::TracingSession> session;
 };
 
 /*
@@ -162,7 +198,6 @@ namespace melatonin
     // https://accu.org/journals/overload/30/172/wu/#_idTextAnchor004
     #define WRAP_COMPILE_TIME_STRING(x) [] { return (x); }
     #define UNWRAP_COMPILE_TIME_STRING(x) (x)()
-
     template <typename CompileTimeLambdaWrappedString>
     constexpr auto compileTimePrettierFunction (CompileTimeLambdaWrappedString wrappedSrc)
     {

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -257,9 +257,9 @@ namespace melatonin
 
 // we also can toggle dsp/component on/off individually to help clean up traces
 #if PERFETTO_ENABLE_TRACE_DSP
-    #define TRACE_DSP(...)                                                                                                            \
+    #define TRACE_DSP(...)                                                                                                                   \
         static constexpr auto pf = melatonin::compileTimePrettierFunction (WRAP_COMPILE_TIME_STRING (PERFETTO_DEBUG_FUNCTION_IDENTIFIER())); \
-        TRACE_EVENT ("dsp", perfetto::StaticString (pf.data()) __VA_OPT__(,) __VA_ARGS__)
+        TRACE_EVENT ("dsp", perfetto::StaticString (pf.data()) __VA_OPT__ (, ) __VA_ARGS__)
 
     #define TRACE_DSP_BEGIN(name) TRACE_EVENT_BEGIN ("dsp", perfetto::StaticString (name))
     #define TRACE_DSP_END() TRACE_EVENT_END ("dsp")
@@ -270,9 +270,9 @@ namespace melatonin
 #endif
 
 #if PERFETTO_ENABLE_TRACE_COMPONENT
-    #define TRACE_COMPONENT(...)                                                                                                      \
+    #define TRACE_COMPONENT(...)                                                                                                             \
         static constexpr auto pf = melatonin::compileTimePrettierFunction (WRAP_COMPILE_TIME_STRING (PERFETTO_DEBUG_FUNCTION_IDENTIFIER())); \
-        TRACE_EVENT ("component", perfetto::StaticString (pf.data()) __VA_OPT__(,) __VA_ARGS__)
+        TRACE_EVENT ("component", perfetto::StaticString (pf.data()) __VA_OPT__ (, ) __VA_ARGS__)
 
     #define TRACE_COMPONENT_BEGIN(name) TRACE_EVENT_BEGIN ("component", perfetto::StaticString (name))
     #define TRACE_COMPONENT_END() TRACE_EVENT_END ("component")

--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -45,6 +45,14 @@ PERFETTO_DEFINE_CATEGORIES (
     perfetto::Category ("dsp")
         .SetDescription ("dsp"));
 
+static constexpr std::uint64_t melatoninGlobalEventTrackId = 0xE1A70515;
+
+    /**
+     * Tracks an instant event, which shows up as an arrow on a separate "Global Events" track in the Perfetto UI.
+     * @param name Describe the event - this is what shows up in the trace.
+     */
+    #define TRACE_GLOBAL_INSTANT(cat, desc) TRACE_EVENT_INSTANT (cat, desc, perfetto::Track (melatoninGlobalEventTrackId));
+
 class MelatoninPerfetto
 {
 public:
@@ -66,6 +74,7 @@ public:
         args.backends = perfetto::kInProcessBackend;
         perfetto::Tracing::Initialize (args);
         perfetto::TrackEvent::Register();
+        registerGlobalEventTrack();
 
         if (startTraceAutomatically)
             beginSession();
@@ -138,6 +147,14 @@ private:
     std::unique_ptr<perfetto::TracingSession> session;
     juce::File traceFile;
     juce::TimedCallback fileWriterCallback;
+
+    static void registerGlobalEventTrack()
+    {
+        auto track = perfetto::Track (melatoninGlobalEventTrackId);
+        auto desc = track.Serialize();
+        desc.set_name ("Global Events");
+        perfetto::TrackEvent::SetTrackDescriptor (track, desc);
+    }
 
     juce::File writeFile()
     {
@@ -298,10 +315,17 @@ namespace melatonin
 
     #define TRACE_DSP_BEGIN(name) TRACE_EVENT_BEGIN ("dsp", perfetto::StaticString (name))
     #define TRACE_DSP_END() TRACE_EVENT_END ("dsp")
+
+    /**
+     * Tracks an instant event, which shows up as an arrow on a separate "Global Events" track in the Perfetto UI.
+     * @param name Describe the event - this is what shows up in the trace.
+     */
+    #define TRACE_DSP_GLOBAL_INSTANT(name) TRACE_GLOBAL_INSTANT ("dsp", perfetto::StaticString (name))
 #else
     #define TRACE_DSP(...)
     #define TRACE_DSP_BEGIN(name)
     #define TRACE_DSP_END()
+    #define TRACE_DSP_GLOBAL_INSTANT(name)
 #endif
 
 #if PERFETTO_ENABLE_TRACE_COMPONENT
@@ -315,4 +339,10 @@ namespace melatonin
     #define TRACE_COMPONENT(...)
     #define TRACE_COMPONENT_BEGIN(name)
     #define TRACE_COMPONENT_END()
+
+    /**
+     * Tracks an instant event, which shows up as an arrow on a separate "Global Events" track in the Perfetto UI.
+     * @param name Describe the event - this is what shows up in the trace.
+     */
+    #define TRACE_COMPONENT_GLOBAL_INSTANT(name) TRACE_GLOBAL_INSTANT ("component", perfetto::StaticString (name))
 #endif

--- a/tests/PerfettoValue/should_be_off.cpp
+++ b/tests/PerfettoValue/should_be_off.cpp
@@ -1,9 +1,9 @@
 #include <melatonin_perfetto/melatonin_perfetto.h>
 
 #ifndef PERFETTO
-  #error The PERFETTO symbol is not defined!
+    #error The PERFETTO symbol is not defined!
 #endif
 
 #if PERFETTO
-  #error The PERFETTO symbol should be defined to 0, but it's not!
+    #error The PERFETTO symbol should be defined to 0, but it's not!
 #endif

--- a/tests/PerfettoValue/should_be_on.cpp
+++ b/tests/PerfettoValue/should_be_on.cpp
@@ -1,9 +1,9 @@
 #include <melatonin_perfetto/melatonin_perfetto.h>
 
 #ifndef PERFETTO
-  #error The PERFETTO symbol is not defined!
+    #error The PERFETTO symbol is not defined!
 #endif
 
 #if ! PERFETTO
-  #error The PERFETTO symbol should be defined to 1, but it's not!
+    #error The PERFETTO symbol should be defined to 1, but it's not!
 #endif


### PR DESCRIPTION
Hey!

This is maybe more of a draft PR - I just added a list of things to make my life easier, but I think at least some of it could be of value to others. May just need some cleaning up and updating docs - I'll be happy to do that.
I just thought I'd discuss it with you before submitting a proper PR. So what do you think? :)

I've added:
- Concurrent trace file writing. Should fix #6. Had to add `juce_events` to have a timed callback.
- `.clang-format` file - just copy/pasted from melatonin_inspector.
- Customisable trace file name. I found this useful for differentiating traces from different builds, e.g. when testing out different optimisations. Added as extra default constructor args, so should be non-breaking.
- `TRACE_DSP_GLOBAL_INSTANT` for tracking instant events. This creates a dedicated track in the trace with an arrow/marker for each event. I'm using this for tracking voice cutoffs in a sampler synth, but it may be useful for tracking any kind of errors. Should prob rename to just `TRACE_GLOBAL_INSTANT`.

All the best,
Christian